### PR TITLE
feat: 컴포넌트 클래스 수정 (#21)

### DIFF
--- a/frontend/components/core/component.js
+++ b/frontend/components/core/component.js
@@ -15,6 +15,8 @@ class Component extends HTMLElement {
 
   init() {
     this.render();
+    this.setStyle();
+    this.shadowRoot?.append(this.styles, this.template.content.cloneNode(true));
     this.addEvent();
   }
 
@@ -38,15 +40,13 @@ class Component extends HTMLElement {
     this.template.innerHTML = this.setTemplate();
   }
 
-  connectedCallback() {
-    this.setStyle();
-    this.shadowRoot?.append(this.styles, this.template.content.cloneNode(true));
-
-    this.setEvent();
-  }
+  /*
+   * componentDidMount
+   */
+  connectedCallback() {}
 
   /*
-   * DOM Unmount
+   * componentWillUnmount
    */
   disconnectedCallback() {}
 

--- a/frontend/components/core/component.js
+++ b/frontend/components/core/component.js
@@ -60,6 +60,8 @@ class Component extends HTMLElement {
   /*
    * 구독한 attribute가 변경되었을 때, Callback 처리
    */
-  attributeChangedCallback(name, oldValue, newValue) {}
+  attributeChangedCallback(name, oldValue, newValue) {
+    this.reRender();
+  }
 }
 export default Component;

--- a/frontend/components/core/component.js
+++ b/frontend/components/core/component.js
@@ -6,22 +6,60 @@ class Component extends HTMLElement {
 
     this.template = document.createElement('template');
     this.styles = document.createElement('style');
+
+    this.attachShadow({ mode: 'open' });
+    this.init();
+
+    this.reRender = this.render.bind(this);
   }
 
-  setStyle() {
-    return;
+  init() {
+    this.render();
+    this.addEvent();
   }
 
+  /*
+   * 각 컴포넌트에서 shadowDOM에 넣을 style을 삽입해줍니다.
+   */
+  setStyle() {}
+
+  /*
+   * 웹컴포넌트 innerHTML
+   */
   setTemplate() {
     return '';
   }
 
-  connectedCallback() {
-    this.attachShadow({ mode: 'open' });
-    this.template.innerHTML = this.setTemplate();
-    this.setStyle();
-
-    this.shadowRoot?.append(this.styles, this.template.content.cloneNode(true));
+  addEvent() {
+    return;
   }
+
+  render() {
+    this.template.innerHTML = this.setTemplate();
+  }
+
+  connectedCallback() {
+    this.setStyle();
+    this.shadowRoot?.append(this.styles, this.template.content.cloneNode(true));
+
+    this.setEvent();
+  }
+
+  /*
+   * DOM Unmount
+   */
+  disconnectedCallback() {}
+
+  /*
+   * attribute 구독
+   */
+  static get observedAttributes() {
+    return [];
+  }
+
+  /*
+   * 구독한 attribute가 변경되었을 때, Callback 처리
+   */
+  attributeChangedCallback(name, oldValue, newValue) {}
 }
 export default Component;


### PR DESCRIPTION
## 📑 개요

컴포넌트 클래스에 웹컴포넌트가 가지는 생명주기 메서드를 명시했습니다.

그리고 이벤트를 추가하는 메서드도 구현했습니다.

`this.reRender` 메서드는 render랑 같은 역할을 합니다.
똑같은 기능을 가진 메서드를 하나 더 추가한 이유는 reRender라는 명칭이 컴포넌트에서 리렌더링해준다는 의미를 더 명확하게 표기해준다고 생각하여 만들었습니다.

## 📎 관련 이슈

[코어 컴포넌트 강화] [#21]

## 💬 작업 내용

- 웹컴포넌트 생명주기 메서드 명시
- 이벤트 추가 메서드 추가
- 렌더 후 이벤트 메서드 실행되도록 설정
- attribute 변경 시, 컴포넌트 리렌더링

## 🚧 PR 특이 사항


