### PR TITLE
feat: 메인 페이지 레이아웃 수정 및 프로젝트 헤더 추가 #23

### DIFF
--- a/frontend/pages/mainPage/index.js
+++ b/frontend/pages/mainPage/index.js
@@ -7,13 +7,16 @@ export default class MainPage extends Component {
   }
 
   setTemplate() {
+    const todoTitle = 'Woowa! Todo🚀';
+    const projectTitle = 'Todo Project!';
+    const projectDesc = '신지호, 김경민이 함께하는 todo project 입니다. with vanilla JS, nodeJS, web component API ...';
     return `
         <div class="main__container">
-          <todo-header text="Woowa! Todo"></todo-header>
+          <todo-header text=${todoTitle}></todo-header>
           <div class="contents__container">
             <div class="project-header">
-              <h1>Todo Project!</h1>
-              <p>신지호, 김경민이 함께하는 todo project 입니다. with vanilla JS, nodeJS, web component API ...</p>
+              <h1>${projectTitle}</h1>
+              <p>${projectDesc}</p>
             </div>
             <div class="kanvan__container">
               <todo-kanvan id="main__kanvan__todo"></todo-kanvan>

--- a/frontend/pages/mainPage/index.js
+++ b/frontend/pages/mainPage/index.js
@@ -10,10 +10,16 @@ export default class MainPage extends Component {
     return `
         <div class="main__container">
           <todo-header text="Woowa! Todo"></todo-header>
-          <div class="kanvan__container">
-            <todo-kanvan id="main__kanvan__todo"></todo-kanvan>
-            <todo-kanvan id="main__kanvan__progress"></todo-kanvan>
-            <todo-kanvan id="main__kanvan__done"></todo-kanvan>
+          <div class="contents__container">
+            <div class="project-header">
+              <h1>Todo Project!</h1>
+              <p>신지호, 김경민이 함께하는 todo project 입니다. with vanilla JS, nodeJS, web component API ...</p>
+            </div>
+            <div class="kanvan__container">
+              <todo-kanvan id="main__kanvan__todo"></todo-kanvan>
+              <todo-kanvan id="main__kanvan__progress"></todo-kanvan>
+              <todo-kanvan id="main__kanvan__done"></todo-kanvan>
+            </div>
           </div>
         </div>
       `;

--- a/frontend/pages/mainPage/style.css
+++ b/frontend/pages/mainPage/style.css
@@ -5,6 +5,27 @@
   display: flex;
   flex-direction: column;
 }
+.contents__container {
+  padding-left: 164px;
+  margin-top: 28px;
+  display: flex;
+  gap: 42px;
+  flex-direction: column;
+}
+.project-header {
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
+}
+.project-header h1 {
+  font-size: 32px;
+  font-weight: 700;
+}
+.project-header p {
+  font-size: 16px;
+  font-weight: 400;
+  color: var(--grey-500);
+}
 .kanvan__container {
   display: flex;
   gap: 48px;


### PR DESCRIPTION
## 📑 개요
메인 페이지 레이아웃 수정 및 프로젝트 헤더 추가
## 📎 관련 이슈

메인 페이지 레이아웃 잡기 [#23 ]

## 💬 작업 내용
<img width="1763" alt="image" src="https://user-images.githubusercontent.com/44824463/178635101-463b606b-68f1-4e79-8fc2-63a6067a59e5.png">
## 🚧 PR 특이 사항
