### PR TITLE
feat: 카드 수정 및 삭제 기능 구현 (#28)

### DIFF
--- a/frontend/components/button/button.css
+++ b/frontend/components/button/button.css
@@ -6,17 +6,23 @@
   border: none;
   cursor: pointer;
 }
+
 .custom-button.primary {
   background-color: var(--purple-200);
 }
 
-.custom-button.primary:hover {
+.custom-button.primary:not(.disabled):hover {
   background-color: var(--purple-300);
 }
 
-.custom-button.primary:active {
+.custom-button.primary:active,
+.custom-button.disabled {
   background-color: var(--purple-100);
   color: rgba(255, 255, 255, 0.4);
+}
+
+.custom-button.disabled {
+  cursor: default;
 }
 
 .custom-button.normal {

--- a/frontend/components/card/card.css
+++ b/frontend/components/card/card.css
@@ -25,15 +25,7 @@
   color: var(--black);
 }
 
-.card__title__input {
-  font-weight: 700;
-  font-size: 20px;
-  line-height: 24px;
-
-  color: var(--black);
-}
-
-.card__title__input::placeholder {
+input.card__title::placeholder {
   color: var(--grey-400);
 }
 

--- a/frontend/components/card/card.css
+++ b/frontend/components/card/card.css
@@ -80,6 +80,8 @@ textarea.card__desc {
 .card__close-btn {
   border: none;
   background-color: transparent;
+
+  cursor: pointer;
 }
 
 .card__button__wrapper {

--- a/frontend/components/card/card.css
+++ b/frontend/components/card/card.css
@@ -59,8 +59,9 @@ p.card__desc {
 }
 
 textarea.card__desc {
-  overflow: auto;
-  text-overflow: initial;
+  resize: none;
+  overflow-y: hidden; /* prevents scroll bar flash */
+  text-overflow: inherit;
 }
 
 .card__tag {

--- a/frontend/components/card/card.css
+++ b/frontend/components/card/card.css
@@ -9,6 +9,11 @@
   background: var(--white);
   border: 1px solid var(--grey-200);
   border-radius: 6px;
+
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .card__header {

--- a/frontend/components/card/card.css
+++ b/frontend/components/card/card.css
@@ -1,3 +1,5 @@
+@import '../../styles/reset.css';
+
 .card {
   padding: 16px;
 
@@ -20,25 +22,45 @@
   font-size: 20px;
   line-height: 24px;
 
-  color: var(--balck);
+  color: var(--black);
+}
+
+.card__title__input {
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 24px;
+
+  color: var(--black);
+}
+
+.card__title__input::placeholder {
+  color: var(--grey-400);
 }
 
 .card__desc {
   margin-top: 8px;
-  width: 252px;
+  width: 100%;
   height: 40px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  word-wrap: break-word;
 
   font-weight: 400;
   font-size: 16px;
   line-height: 19px;
 
   color: var(--grey-500);
+}
+
+p.card__desc {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-wrap: break-word;
+}
+
+textarea.card__desc {
+  overflow: auto;
+  text-overflow: initial;
 }
 
 .card__tag {
@@ -53,4 +75,17 @@
 
   background-color: var(--purple-200);
   color: var(--white);
+}
+
+.card__close-btn {
+  border: none;
+  background-color: transparent;
+}
+
+.card__button__wrapper {
+  margin-top: 16px;
+
+  display: flex;
+  justify-content: center;
+  gap: 8px;
 }

--- a/frontend/components/card/card.js
+++ b/frontend/components/card/card.js
@@ -2,24 +2,82 @@ import Component from '../core/component.js';
 import cardStyle from './card.css';
 import IconClose from '../../assets/icons/close.svg';
 
+const CARD_TYPE = {
+  NORMAL: 'NORMAL',
+  MODIFY: 'MODIFY',
+};
+
 class Card extends Component {
   constructor() {
     super();
+
+    this.cardType = CARD_TYPE.NORMAL;
+
+    this.reRender();
+    this.addEvent();
   }
 
   setStyle() {
     this.styles.textContent = cardStyle;
   }
 
+  handleDlbClickCard(e) {
+    e.stopPropagation();
+    e.preventDefault();
+
+    if (this.cardType === CARD_TYPE.MODIFY) return;
+
+    this.cardType = CARD_TYPE.MODIFY;
+    this.reRender();
+  }
+
+  handleClickCloseButton(e) {
+    e.stopPropagation();
+
+    console.log('delete');
+  }
+
+  addEvent() {
+    this.addEventListener('dblclick', this.handleDlbClickCard.bind(this));
+  }
+
   setTemplate() {
-    return `<div class="card">
-    <div class="card__header">
-      <p class="card__title">GitHub 공부하기</p>
-      <img src=${IconClose} alt="삭제" />
-    </div>
-    <p class="card__desc">add, commit, push</p>
-    <button class="card__tag">Git</button>
-  </div>`;
+    if (this.cardType === CARD_TYPE.NORMAL) return this.getNormalCardTemplate();
+
+    if (this.cardType === CARD_TYPE.MODIFY) return this.getModifyCardTemplate();
+
+    // return this.getNormalCardTemplate();
+  }
+
+  getNormalCardTemplate() {
+    return `
+    <div class="card">
+      <div class="card__header">
+        <p class="card__title">${this.getAttribute('title')}</p>
+        <button class="card__close-btn">
+          <img src=${IconClose} alt="삭제" />
+        </button>
+      </div>
+      <p class="card__desc">${this.getAttribute('description')}</p>
+    </div>`;
+  }
+
+  getModifyCardTemplate() {
+    return `
+    <div class="card">
+      <div class="card__header">
+        <input class="card__title__input" placeholder="제목을 입력하세요." value=${this.getAttribute('title')} />
+      </div>
+      <textarea class="card__desc" placeholder="내용을 입력해주세요.">${this.getAttribute('description')}</textarea>
+      <div class="card__button__wrapper">
+        <custom-button text="취소"></custom-button>
+        <custom-button type="primary" text="등록"></custom-button>
+      </div>
+    </div>`;
+  }
+
+  static get observedAttributes() {
+    return ['title', 'description'];
   }
 }
 

--- a/frontend/components/card/card.js
+++ b/frontend/components/card/card.js
@@ -49,11 +49,21 @@ class Card extends Component {
     console.log('submit');
   }
 
+  handleKeydownTextArea(e) {
+    const descriptionTextArea = e.target;
+
+    console.log(descriptionTextArea.scrollHeight);
+
+    descriptionTextArea.style.height = 'auto';
+    descriptionTextArea.style.height = `${descriptionTextArea.scrollHeight}px`;
+  }
+
   setEvent() {
     this.addEvent('dblclick', '.card', this.handleDlbClickCard.bind(this));
     this.addEvent('click', '.card__close-btn', this.handleClickCloseButton.bind(this));
     this.addEvent('click', '#card__cancel-btn', this.handleClickCancelButton.bind(this));
     this.addEvent('click', '#card__submit-btn', this.handleClickSubmitButton.bind(this));
+    this.addEvent('keydown', 'textarea.card__desc', this.handleKeydownTextArea.bind(this));
   }
 
   setTemplate() {

--- a/frontend/components/card/card.js
+++ b/frontend/components/card/card.js
@@ -21,13 +21,21 @@ class Card extends Component {
     this.styles.textContent = cardStyle;
   }
 
+  toggleCardType() {
+    if (this.cardType === CARD_TYPE.MODIFY) {
+      this.cardType = CARD_TYPE.NORMAL;
+    } else {
+      this.cardType = CARD_TYPE.MODIFY;
+    }
+  }
+
   handleDlbClickCard(e) {
     e.stopPropagation();
     e.preventDefault();
 
     if (this.cardType === CARD_TYPE.MODIFY) return;
 
-    this.cardType = CARD_TYPE.MODIFY;
+    this.toggleCardType();
     this.reRender();
   }
 
@@ -36,13 +44,31 @@ class Card extends Component {
   }
 
   handleClickCancelButton(e) {
-    this.cardType = CARD_TYPE.NORMAL;
+    this.toggleCardType();
 
     this.reRender();
   }
 
   handleClickSubmitButton(e) {
     e.stopPropagation();
+    const inputTitle = this.shadowRoot.querySelector('input.card__title');
+
+    if (!inputTitle.value) return;
+
+    this.cardType = CARD_TYPE.NORMAL;
+    const descriptionTextArea = this.shadowRoot.querySelector('textarea.card__desc');
+    this.setAttribute('description', descriptionTextArea.value);
+  }
+
+  handleInputTitle(e) {
+    const { value: inputValue } = e.target;
+    const submitButton = this.shadowRoot.querySelector('#card__submit-btn').shadowRoot.querySelector('.custom-button');
+
+    if (inputValue) {
+      submitButton.classList.remove('disabled');
+    } else {
+      submitButton.classList.add('disabled');
+    }
   }
 
   handleKeydownTextArea(e) {
@@ -58,6 +84,7 @@ class Card extends Component {
     this.addEvent('click', '#card__cancel-btn', this.handleClickCancelButton.bind(this));
     this.addEvent('click', '#card__submit-btn', this.handleClickSubmitButton.bind(this));
     this.addEvent('keydown', 'textarea.card__desc', this.handleKeydownTextArea.bind(this));
+    this.addEvent('input', 'input.card__title', this.handleInputTitle.bind(this));
   }
 
   setTemplate() {
@@ -83,7 +110,7 @@ class Card extends Component {
     return `
     <div class="card">
       <div class="card__header">
-        <input class="card__title__input" placeholder="제목을 입력하세요." value=${this.getAttribute('title')} />
+        <input class="card__title" placeholder="제목을 입력하세요." value=${this.getAttribute('title')} />
       </div>
       <textarea class="card__desc" placeholder="내용을 입력해주세요.">${this.getAttribute('description')}</textarea>
       <div class="card__button__wrapper">

--- a/frontend/components/card/card.js
+++ b/frontend/components/card/card.js
@@ -14,7 +14,7 @@ class Card extends Component {
     this.cardType = CARD_TYPE.NORMAL;
 
     this.reRender();
-    this.addEvent();
+    this.setEvent();
   }
 
   setStyle() {
@@ -30,9 +30,6 @@ class Card extends Component {
   }
 
   handleDlbClickCard(e) {
-    e.stopPropagation();
-    e.preventDefault();
-
     if (this.cardType === CARD_TYPE.MODIFY) return;
 
     this.toggleCardType();
@@ -41,6 +38,12 @@ class Card extends Component {
 
   handleClickCloseButton(e) {
     e.stopPropagation();
+
+    const alertModalComponent = document.querySelector('#main__page').shadowRoot.querySelector('#alert__modal');
+    alertModalComponent.setAttribute('card-id', this.getAttribute('card-id'));
+    const alertModal = alertModalComponent.shadowRoot.querySelector('.modal');
+
+    alertModal.classList.add('open');
   }
 
   handleClickCancelButton(e) {
@@ -103,7 +106,8 @@ class Card extends Component {
         </button>
       </div>
       <p class="card__desc">${this.getAttribute('description')}</p>
-    </div>`;
+    </div>
+    `;
   }
 
   getModifyCardTemplate() {

--- a/frontend/components/card/card.js
+++ b/frontend/components/card/card.js
@@ -30,7 +30,7 @@ class Card extends Component {
     }
   }
 
-  handleDlbClickCard(e) {
+  handleDoubleClickCard(e) {
     if (this.cardType === CARD_TYPE.MODIFY) return;
 
     this.toggleCardType();

--- a/frontend/components/card/card.js
+++ b/frontend/components/card/card.js
@@ -1,6 +1,7 @@
 import Component from '../core/component.js';
 import cardStyle from './card.css';
 import IconClose from '../../assets/icons/close.svg';
+import { openAlertModal } from '../../utils/modalUtil.js';
 
 const CARD_TYPE = {
   NORMAL: 'NORMAL',
@@ -39,11 +40,10 @@ class Card extends Component {
   handleClickCloseButton(e) {
     e.stopPropagation();
 
-    const alertModalComponent = document.querySelector('#main__page').shadowRoot.querySelector('#alert__modal');
-    alertModalComponent.setAttribute('card-id', this.getAttribute('card-id'));
-    const alertModal = alertModalComponent.shadowRoot.querySelector('.modal');
+    const alertModal = document.querySelector('alert-modal');
+    alertModal.setAttribute('card-id', this.getAttribute('card-id'));
 
-    alertModal.classList.add('open');
+    openAlertModal();
   }
 
   handleClickCancelButton(e) {

--- a/frontend/components/card/card.js
+++ b/frontend/components/card/card.js
@@ -33,8 +33,6 @@ class Card extends Component {
 
   handleClickCloseButton(e) {
     e.stopPropagation();
-
-    console.log('delete');
   }
 
   handleClickCancelButton(e) {
@@ -45,14 +43,10 @@ class Card extends Component {
 
   handleClickSubmitButton(e) {
     e.stopPropagation();
-
-    console.log('submit');
   }
 
   handleKeydownTextArea(e) {
     const descriptionTextArea = e.target;
-
-    console.log(descriptionTextArea.scrollHeight);
 
     descriptionTextArea.style.height = 'auto';
     descriptionTextArea.style.height = `${descriptionTextArea.scrollHeight}px`;

--- a/frontend/components/card/card.js
+++ b/frontend/components/card/card.js
@@ -37,16 +37,29 @@ class Card extends Component {
     console.log('delete');
   }
 
-  addEvent() {
-    this.addEventListener('dblclick', this.handleDlbClickCard.bind(this));
+  handleClickCancelButton(e) {
+    this.cardType = CARD_TYPE.NORMAL;
+
+    this.reRender();
+  }
+
+  handleClickSubmitButton(e) {
+    e.stopPropagation();
+
+    console.log('submit');
+  }
+
+  setEvent() {
+    this.addEvent('dblclick', '.card', this.handleDlbClickCard.bind(this));
+    this.addEvent('click', '.card__close-btn', this.handleClickCloseButton.bind(this));
+    this.addEvent('click', '#card__cancel-btn', this.handleClickCancelButton.bind(this));
+    this.addEvent('click', '#card__submit-btn', this.handleClickSubmitButton.bind(this));
   }
 
   setTemplate() {
     if (this.cardType === CARD_TYPE.NORMAL) return this.getNormalCardTemplate();
 
     if (this.cardType === CARD_TYPE.MODIFY) return this.getModifyCardTemplate();
-
-    // return this.getNormalCardTemplate();
   }
 
   getNormalCardTemplate() {
@@ -70,8 +83,8 @@ class Card extends Component {
       </div>
       <textarea class="card__desc" placeholder="내용을 입력해주세요.">${this.getAttribute('description')}</textarea>
       <div class="card__button__wrapper">
-        <custom-button text="취소"></custom-button>
-        <custom-button type="primary" text="등록"></custom-button>
+        <custom-button id="card__cancel-btn" text="취소"></custom-button>
+        <custom-button id="card__submit-btn" type="primary" text="등록"></custom-button>
       </div>
     </div>`;
   }

--- a/frontend/components/core/component.js
+++ b/frontend/components/core/component.js
@@ -9,15 +9,13 @@ class Component extends HTMLElement {
 
     this.attachShadow({ mode: 'open' });
     this.init();
-
-    this.reRender = this.render.bind(this);
   }
 
   init() {
     this.render();
     this.setStyle();
     this.shadowRoot?.append(this.styles, this.template.content.cloneNode(true));
-    this.addEvent();
+    // this.addEvent();
   }
 
   /*
@@ -32,12 +30,31 @@ class Component extends HTMLElement {
     return '';
   }
 
-  addEvent() {
-    return;
+  /*
+   * 컴포넌트 이벤트를 넣어줍니다.
+   */
+  setEvent() {}
+
+  addEvent(event, selector, cb) {
+    const children = [...this.shadowRoot.querySelectorAll(selector)];
+    const isTarget = (target) => children.includes(target) || target.closest(selector);
+
+    this.shadowRoot.addEventListener(event, (e) => {
+      if (isTarget(e.target)) cb(e);
+    });
   }
 
   render() {
     this.template.innerHTML = this.setTemplate();
+  }
+
+  reRender() {
+    this.render();
+
+    this.shadowRoot.innerHTML = '';
+    this.shadowRoot.append(this.styles, this.template.content.cloneNode(true));
+
+    this.setEvent();
   }
 
   /*

--- a/frontend/components/core/component.js
+++ b/frontend/components/core/component.js
@@ -39,9 +39,15 @@ class Component extends HTMLElement {
     const children = [...this.shadowRoot.querySelectorAll(selector)];
     const isTarget = (target) => children.includes(target) || target.closest(selector);
 
-    this.shadowRoot.addEventListener(event, (e) => {
-      if (isTarget(e.target)) cb(e);
+    children.forEach((element) => {
+      element.addEventListener(event, (e) => {
+        cb(e);
+      });
     });
+
+    // this.shadowRoot.addEventListener(event, (e) => {
+    // if (isTarget(e.target)) cb(e);
+    // });
   }
 
   render() {

--- a/frontend/components/core/component.js
+++ b/frontend/components/core/component.js
@@ -37,17 +37,12 @@ class Component extends HTMLElement {
 
   addEvent(event, selector, cb) {
     const children = [...this.shadowRoot.querySelectorAll(selector)];
-    const isTarget = (target) => children.includes(target) || target.closest(selector);
 
     children.forEach((element) => {
       element.addEventListener(event, (e) => {
         cb(e);
       });
     });
-
-    // this.shadowRoot.addEventListener(event, (e) => {
-    // if (isTarget(e.target)) cb(e);
-    // });
   }
 
   render() {

--- a/frontend/components/kanvanBoard/kanvanBoard.js
+++ b/frontend/components/kanvanBoard/kanvanBoard.js
@@ -3,6 +3,25 @@ import Component from '../core/component.js';
 import IconClose from '../../assets/icons/close.svg';
 import IconPlus from '../../assets/icons/plus.svg';
 
+const DUMMY = [
+  {
+    title: 'test',
+    description: 'abc',
+  },
+  {
+    title: 'test',
+    description: 'abc',
+  },
+  {
+    title: 'test',
+    description: 'abc',
+  },
+  {
+    title: 'test',
+    description: 'abc',
+  },
+];
+
 class KanvanBoard extends Component {
   constructor() {
     super();
@@ -25,7 +44,9 @@ class KanvanBoard extends Component {
           </div>
         </div>
         <div class="kanvan__card__list">
-            <todo-card></todo-card>
+            ${DUMMY.map(
+              (data) => `<todo-card title="${data.title}" description="${data.description}"></todo-card>`,
+            ).join('')}
         </div>
       </div>`;
   }

--- a/frontend/components/kanvanBoard/kanvanBoard.js
+++ b/frontend/components/kanvanBoard/kanvanBoard.js
@@ -5,19 +5,23 @@ import IconPlus from '../../assets/icons/plus.svg';
 
 const DUMMY = [
   {
-    title: 'test',
+    id: 1,
+    title: 'test1',
     description: 'abc',
   },
   {
-    title: 'test',
+    id: 2,
+    title: 'test2',
     description: 'abc',
   },
   {
-    title: 'test',
+    id: 3,
+    title: 'test3',
     description: 'abc',
   },
   {
-    title: 'test',
+    id: 4,
+    title: 'test4',
     description: 'abc',
   },
 ];
@@ -45,7 +49,8 @@ class KanvanBoard extends Component {
         </div>
         <div class="kanvan__card__list">
             ${DUMMY.map(
-              (data) => `<todo-card title="${data.title}" description="${data.description}"></todo-card>`,
+              (data) =>
+                `<todo-card title="${data.title}" description="${data.description}" card-id="${data.id}"></todo-card>`,
             ).join('')}
         </div>
       </div>`;

--- a/frontend/components/modal/alertModal.css
+++ b/frontend/components/modal/alertModal.css
@@ -1,7 +1,7 @@
 @import '../../styles/reset.css';
 @import '../../styles/style.css';
 
-.modal {
+.modal.open {
   z-index: 1000;
   position: fixed;
   top: 0;
@@ -13,6 +13,10 @@
 
   width: 100vw;
   height: 100vh;
+}
+
+.modal {
+  display: none;
 }
 
 .modal__background {

--- a/frontend/components/modal/alertModal.js
+++ b/frontend/components/modal/alertModal.js
@@ -26,11 +26,12 @@ class AlertModal extends Component {
 
   handleClickDeleteButton() {
     const cardId = this.getAttribute('card-id');
-    const card = [...document.querySelector('main-page').shadowRoot.querySelectorAll('todo-kanvan')].map(
-      (kanvanBoard) => kanvanBoard.shadowRoot.querySelectorAll(`todo-card[card-id=${cardId}]`),
+    const [card] = [...document.querySelector('main-page').shadowRoot.querySelectorAll('todo-kanvan')].map(
+      (kanvanBoard) => kanvanBoard.shadowRoot.querySelector(`todo-card[card-id="${cardId}"]`),
     );
-    // card.remove();
-    console.log(card);
+
+    card.remove();
+
     // TODO : Delete API 호출
     this.close();
   }

--- a/frontend/components/modal/alertModal.js
+++ b/frontend/components/modal/alertModal.js
@@ -2,19 +2,53 @@ import Component from '../core/component.js';
 import alertModalStyle from './alertModal.css';
 
 class AlertModal extends Component {
+  constructor() {
+    super();
+
+    this.setEvent();
+  }
+
+  open() {
+    this.shadowRoot.querySelector('.modal').classList.add('open');
+  }
+
+  close() {
+    this.shadowRoot.querySelector('.modal').classList.remove('open');
+  }
+
   setStyle() {
     this.styles.textContent = alertModalStyle;
   }
 
+  handleClickCancelButton() {
+    this.close();
+  }
+
+  handleClickDeleteButton() {
+    const cardId = this.getAttribute('card-id');
+    const card = [...document.querySelector('main-page').shadowRoot.querySelectorAll('todo-kanvan')].map(
+      (kanvanBoard) => kanvanBoard.shadowRoot.querySelectorAll(`todo-card[card-id=${cardId}]`),
+    );
+    // card.remove();
+    console.log(card);
+    // TODO : Delete API 호출
+    this.close();
+  }
+
+  setEvent() {
+    this.addEvent('click', '#modal__cancel-btn', this.handleClickCancelButton.bind(this));
+    this.addEvent('click', '#modal__delete-btn', this.handleClickDeleteButton.bind(this));
+  }
+
   setTemplate() {
-    return ` 
+    return `
     <div class="modal">
       <div class="modal__background"></div>
       <div class="modal__content">
         <h5 class="modal__title">선택한 카드를 삭제할까요?</h5>
         <div class="modal__button__wrapper">
-          <custom-button text="취소"></custom-button>
-          <custom-button type="primary" text="삭제"></custom-button>
+          <custom-button id="modal__cancel-btn" text="취소"></custom-button>
+          <custom-button id="modal__delete-btn" type="primary" text="삭제"></custom-button>
         </div>
       </div>
     </div>`;

--- a/frontend/pages/mainPage/index.js
+++ b/frontend/pages/mainPage/index.js
@@ -20,11 +20,14 @@ export default class MainPage extends Component {
             </div>
             <div class="kanvan__container">
               <todo-kanvan id="main__kanvan__todo"></todo-kanvan>
-              <todo-kanvan id="main__kanvan__progress"></todo-kanvan>
-              <todo-kanvan id="main__kanvan__done"></todo-kanvan>
             </div>
           </div>
         </div>
       `;
   }
+}
+
+{
+  /* <todo-kanvan id="main__kanvan__progress"></todo-kanvan>
+              <todo-kanvan id="main__kanvan__done"></todo-kanvan> */
 }

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -6,6 +6,7 @@
     <title>to do list</title>
   </head>
   <body>
-    <main-page></main-page>
+    <main-page id="main__page"></main-page>
+    <alert-modal id="alert__modal"></alert-modal>
   </body>
 </html>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,5 +7,6 @@
   </head>
   <body>
     <main-page></main-page>
+    <alert-modal></alert-modal>
   </body>
 </html>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,6 +7,5 @@
   </head>
   <body>
     <main-page></main-page>
-    <alert-modal></alert-modal>
   </body>
 </html>

--- a/frontend/styles/reset.css
+++ b/frontend/styles/reset.css
@@ -127,9 +127,9 @@ a {
   text-decoration: none;
 }
 
+textarea,
 input {
   border: none;
-  padding: 10px 0;
 }
 
 input:focus {

--- a/frontend/utils/modalUtil.js
+++ b/frontend/utils/modalUtil.js
@@ -1,0 +1,17 @@
+export const openAlertModal = () => {
+  const alertModal = document
+    .querySelector('#main__page')
+    .shadowRoot.querySelector('#alert__modal')
+    .shadowRoot.querySelector('.modal');
+
+  alertModal.classList.add('open');
+};
+
+export const closeAlertModal = () => {
+  const alertModal = document
+    .querySelector('#main__page')
+    .shadowRoot.querySelector('#alert__modal')
+    .shadowRoot.querySelector('.modal');
+
+  alertModal.classList.remove('open');
+};

--- a/frontend/utils/modalUtil.js
+++ b/frontend/utils/modalUtil.js
@@ -1,17 +1,11 @@
 export const openAlertModal = () => {
-  const alertModal = document
-    .querySelector('#main__page')
-    .shadowRoot.querySelector('#alert__modal')
-    .shadowRoot.querySelector('.modal');
+  const alertModal = document.querySelector('alert-modal').shadowRoot.querySelector('.modal');
 
   alertModal.classList.add('open');
 };
 
 export const closeAlertModal = () => {
-  const alertModal = document
-    .querySelector('#main__page')
-    .shadowRoot.querySelector('#alert__modal')
-    .shadowRoot.querySelector('.modal');
+  const alertModal = document.querySelector('alert-modal').shadowRoot.querySelector('.modal');
 
   alertModal.classList.remove('open');
 };

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -7,8 +7,9 @@ export default {
   entry: './frontend/app.js',
   mode: 'development',
   output: {
-    filename: 'main.js',
     path: path.resolve(__dirname, 'dist'),
+    filename: '[name].js',
+    publicPath: '/',
   },
   module: {
     rules: [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev:server": "nodemon backend/app.js",
-    "dev:frontend": "webpack serve --config ./frontend/webpack.config.js --mode development",
+    "dev:frontend": "webpack serve --config ./frontend/webpack.config.js",
     "lint": "eslint frontend/**/*.ts",
     "lint:fix": "eslint frontend/**/*.ts --fix",
     "build:frontend": "webpack --config ./frontend/webpack.config.js"


### PR DESCRIPTION
## 📑 개요

카드 수정 및 삭제 기능 구현

## 📎 관련 이슈

[카드 수정 및 삭제 기능 구현] [#28]

## 💬 작업 내용

카드를 더블클릭 하면 수정 가능해진다.
카드 수정 기능 (title이 없으면 저장이 안된다.)
카드의 X 버튼을 누르면 삭제 모달이 뜨고, 삭제가 가능하다.

## 🚧 PR 특이 사항

전에 만들었던 이슈의 기능 단위가 너무 커서 쪼개서 먼저 PR 올립니다.

